### PR TITLE
Overriding onExceed fixed

### DIFF
--- a/jquery.materialize-autocomplete.js
+++ b/jquery.materialize-autocomplete.js
@@ -377,7 +377,7 @@
             if (self.value.length >= self.options.multiple.maxSize) {
 
                 if ('function' === typeof self.options.multiple.onExceed) {
-                    self.options.multiple.onExceed.call(this, self.options.multiple.maxSize);
+                    self.options.multiple.onExceed.call(undefined, self.options.multiple.maxSize, item);
                 }
 
                 return false;


### PR DESCRIPTION
The item-object that is passed with the **onExceed** method is undefined. I found three different issues with the code, which I fixed:
1. The first parameter of the **onExceed.call** method was missing. I've added _undefined_ as default value since it's unclear where this first parameter is used for.
2. The **item** object that causes the **onExceed** method to trigger was never passed to the method. Instead **this** was passed, which is not equal to the **item** object. Passed the correct object now.
3. The parameter order was incorrect. The **maxSize** parameter was passed as second parameter and according to the documentation it should be passed as first parameter, followed by the **item**.

This fix should also be applied to the minified version after being approved.
