### PR TITLE
Missing equals sign to print variable value

### DIFF
--- a/jquery.materialize-autocomplete.js
+++ b/jquery.materialize-autocomplete.js
@@ -114,7 +114,7 @@
             el: '',
             tagName: 'ul',
             className: 'ac-appender',
-            tagTemplate: '<div class="chip" data-id="<%= item.id %>" data-text="<% item.text %>"><%= item.text %>(<%= item.id %>)<i class="material-icons close">close</i></div>'
+            tagTemplate: '<div class="chip" data-id="<%= item.id %>" data-text="<%= item.text %>"><%= item.text %>(<%= item.id %>)<i class="material-icons close">close</i></div>'
         },
         dropdown: {
             el: '',


### PR DESCRIPTION
Added the missing equals sign (underscoreJS) to print the value of the item property.
